### PR TITLE
Fix issue of maskImage cannot be loaded on some android devices.

### DIFF
--- a/js/results-app.js
+++ b/js/results-app.js
@@ -179,7 +179,10 @@ function renderResultRow(result, pointDefinition, container, locale) {
 
     let iconEl = document.createElement('div')
     iconEl.className = 'result-icon'
-    iconEl.style.maskImage = `url("assets/svg/${pointDefinition.key}.svg")`
+    iconEl.style.background = `url("assets/svg/${pointDefinition.key}.svg")`
+    iconEl.style.backgroundSize = 'contain'
+    iconEl.style.backgroundRepeat = 'no-repeat'
+    iconEl.style.backgroundPosition = 'center'
 
     let nameLabel = document.createElement('span')
     nameLabel.className = "result-name"


### PR DESCRIPTION
In my test, element with attr of `maskImage` cannot be loaded on MMA devices. 
But the head image can be loaded because it using `background`.
So for compatibility, we may need to change to `background`, how do you think? @talal-nuralogix 
Note: I found that when using `background` for element, the color of element always black.
![image](https://github.com/user-attachments/assets/70dc07f5-55cf-403b-805e-f422030decb4)
